### PR TITLE
Fixed tensordecomposition error for high dimensions. 

### DIFF
--- a/src/simplex_split.jl
+++ b/src/simplex_split.jl
@@ -6,16 +6,17 @@
 function simplex_split(k::Int, d::Int; orientations = false)
 
     sequences::Array{Int, 2} = tensordecomposition(k, d)
-
     n_seq = size(sequences, 1)
-    χ::Array{Int, 2} = sequences .* (d+1) + repmat(collect(1:d).', n_seq , 1)
 
+    χ1 = sequences .* (d + 1)
+    χ2 = repmat(collect(1:d).', n_seq, 1)
+    χ::Array{Int, 2} = χ1 .+ χ2
     χ = sort(χ, 2)
 
     matrices_simplicial_subdivision::Array{Int, 2} = zeros((d + 1) * k^d, k)
 
-    for a = 1:size(sequences, 1)
-        tmp = ones(Int, k * (d+1), 1)
+    for a = 1:n_seq
+        tmp = ones(Int, k * (d+1))
         for b = 1:(d-1)
             tmp[(χ[a, b] + 1):(χ[a, b+1])] = (b+1) * ones(χ[a, b+1] - χ[a, b], 1)
         end

--- a/src/simplex_subdivision.jl
+++ b/src/simplex_subdivision.jl
@@ -48,10 +48,10 @@ function simplicial_subdivision(k::Int, E::Int)
 
     V::Array{Int, 2} = repmat(uniquelabels, 1, E + 1)
 
-    @show tmp = repmat((((E+1)^k - 1) ./ E) * collect(0:E).', n_rows, 1)
+    tmp = repmat((((E+1)^k - 1) ./ E) * collect(0:E).', n_rows, 1)
 
-    @show tmp = heaviside0(-abs.(V - tmp)) .* repmat(collect(1:n_rows), 1, E + 1)
-    @show tmp = tmp[find(tmp)]
+    tmp = heaviside0(-abs.(V - tmp)) .* repmat(collect(1:n_rows), 1, E + 1)
+    tmp = tmp[find(tmp)]
 
     aux = round.(Int, tmp)
     Caux = round.(Int, complementary(tmp, n_rows))

--- a/src/tensordecomposition.jl
+++ b/src/tensordecomposition.jl
@@ -1,17 +1,38 @@
-""" Decomposition of the integers  0:(k^p - 1) in powers of k.
+"""
+    tensordecomposition(k::Int, d::Int)
+
+Decomposition of the integers  0:(k^p - 1) in powers of k.
+
 
 """
-function tensordecomposition(k::Int, p::Int)
+function tensordecomposition(k::Int, d::Int)
 
-    t::Vector{Int} = collect(0:k^p-1)
-    exponent::Array{Float64, 2} = repmat((1 ./ k .^ collect(0:p-1)).', k^p, 1)
+    sequences = zeros(Integer, k^d, d)
 
-    T::Array{Int, 2} = floor.(repmat(t, 1, p) .* exponent)
-    T[:, 1:p-1] = T[:, 1:p-1] - k .* T[:, 2:p]
+    for n = 0:k^d-1
+        i = d
+        m = n
 
-    # Returns an array of dimension k^p x p.
-    # Each row contains the decomposition of the index of the row minus one
+        while i > 0
+            i = i - 1
+            j = i
+            f = floor(Int, m / k^i)
 
-    return T
+            while j > 0 && f == 0
+                j = j - 1
+                f = floor(Integer, m / k^j)
+            end
 
+            if f > 0
+                sequences[n + 1, j + 1] = f
+                i = j
+            elseif f == 0
+                sequences[n + 1, 1] = m
+                i = 0
+            end
+            m = m - f * k^i
+        end
+    end
+
+    return sequences
 end

--- a/test/test_tensordecomposition.jl
+++ b/test/test_tensordecomposition.jl
@@ -1,11 +1,10 @@
 @testset "Tensor decomposition" begin
-    @testset "k = $k" for k in 1:5
-        @testset "p = $p" for p in 1:5
+    @testset "k = $k" for k in 1:7
+        @testset "p = $p" for p in 1:7
             # Check that inverse of decomposition yields the original sequence
             # of integers.
             decomp = tensordecomposition(k, p)
-            original_sequence = collect(0:k^p - 1)
-
+            original_sequence = collect(0:(k^p - 1))
             @test all(decomp * k .^ collect(0:p-1) .== original_sequence)
         end
     end


### PR DESCRIPTION
Fixed error where `tensordecomposition` failed (due to some weird error when using matrices instead of for loop; need to look into this).